### PR TITLE
Wire fix

### DIFF
--- a/Seeed_QTouch.cpp
+++ b/Seeed_QTouch.cpp
@@ -27,7 +27,9 @@
 
 SeeedQTouch::SeeedQTouch()
 {
-    Wire.begin();
+//    Wire.begin(); // Starting Wire in this file causes my NodeMCU to enter boot mode
+                    // with the following message:
+                    // ets Jan  8 2013,rst cause:2, boot mode:(1,6)
 }
 
 // if certain key touched, return 1 - touched, 0 untouched

--- a/examples/isTouch/isTouch.ino
+++ b/examples/isTouch/isTouch.ino
@@ -12,6 +12,7 @@
 void setup()
 {   
     Serial.begin(9600);
+    Wire.begin()
 }
 
 void loop()


### PR DESCRIPTION
I was having problems getting the examples from this library to run properly on my NodeMCU. I removed the Wire.begin() from the library and added it in the setup() function and everything runs correctly now.