### PR TITLE
Added functions: setGroup() and chipPresent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,20 @@ Seeed QTouch
 
 [Grove-Q Touch Sensor](https://www.seeedstudio.com/s/Grove-Q-Touch-Sensor-p-1854.html)
 
-LED Bar, common in volume display, is a common sensor component to display analog value. You can use a row of discrete LED lights to make division of this effect, you can also use our element mentioned here. 
+LED Bar, common in volume display, is a common sensor component to display analog value. You can use a row of discrete LED lights to make division of this effect, you can also use our element mentioned here.
 
 For more information, please refer to [wiki][1]
 
-#Usage
+# Usage
 
 1. To judge certain key if touched
 
-
 		unsigned char isTouch(int key)		// key- 0~6, if touched return 1
 2. Get touch state
-   
-   	bits 0 to 6 indicate which keys are in detection, if any. Touched keys report as 1, untouched or disabled
-    keys report as 0.
 
-		unsigned char getState()			// will 
+   bits 0 to 6 indicate which keys are in detection, if any. Touched keys report as 1, untouched or disabled keys report as 0.
+
+		unsigned char getState();
 
 3. Get Touch Num
 
@@ -28,6 +26,19 @@ For more information, please refer to [wiki][1]
 
 	if no touched, return -1. or will return the touched key number.
 
+4. Set group for a key
+
+	   setGroup(uint8_t key, uint8_t group);
+
+	This is used to assign keys to group of which only one can be pressed at a time.
+	Valid group numbers: 0~3, group 255 disables the key.
+
+5. Query if the touch sensor IC is present
+
+     int chipPresent();
+
+	Returns 1 if the chip ID matches, 0 if not or no reply.
+	
 ----
 This software is written by Loovee for seeed studio<br>
 and is licensed under [The MIT License](http://opensource.org/licenses/mit-license.php). Check License.txt for more information.<br>

--- a/Seeed_QTouch.cpp
+++ b/Seeed_QTouch.cpp
@@ -30,6 +30,17 @@ SeeedQTouch::SeeedQTouch()
     Wire.begin();
 }
 
+
+// Check chip ID
+int SeeedQTouch::chipPresent()
+{
+    if (readReg(QTOUCH_REG_CHIPID) == 0x2e)
+    {
+        return 1;
+    }
+    return 0;
+}
+
 // if certain key touched, return 1 - touched, 0 untouched
 unsigned char SeeedQTouch::isTouch(int key)
 {
@@ -59,6 +70,30 @@ int SeeedQTouch::touchNum()
     
     return -1;
 }
+
+// Set group (0-3) for a key or disable the key (255)
+int SeeedQTouch::setGroup(uint8_t key, uint8_t group) {
+  uint8_t value;
+  if (key > 6) {
+		return -1;
+	}
+  if (group < 4) {
+    value = readReg(QTOUCH_REG_AVEASK0 + key) & 0xfc;
+		if (value == 0) {
+			value = 8 << 2; //AVE default
+		}
+  }
+  else if (group == 0xff) {
+    value = 0; //Key disabled
+    group = 1; //AKS default
+  }
+  else {
+    return -1;
+  }
+  writeReg(QTOUCH_REG_AVEASK0 + key, value | group);
+	return 0;
+}
+
 
 // read register
 unsigned char SeeedQTouch::readReg(unsigned char addr_reg)

--- a/Seeed_QTouch.h
+++ b/Seeed_QTouch.h
@@ -54,6 +54,8 @@ public:
     unsigned char isTouch(int key);                     // if certain key touched, return 1 - touched, 0 untouched
     unsigned char getState();                           // return all key state, bit0 for key0, bit1 for key1....
     int touchNum();                                     // if no touch return -1, else return key number 
+    int setGroup(uint8_t key, uint8_t group);		// set key group or disable a key (group 255)
+    int chipPresent();					// check if the chip is present												// check chip ID
 
 	void setNTHRForKey(char nthr,char pin)
 	{


### PR DESCRIPTION
Needed these two features for my project and added them.
setGroup() is very useful for flexible key configuration or the guard channel. chipPresent() queries the chip ID and is used to find out if the chip is connected. Also updated the README.md regarding both functions.