### PR TITLE
added "void" keyword to "SeeedQTouch::chipPresent()"

### DIFF
--- a/Seeed_QTouch.cpp
+++ b/Seeed_QTouch.cpp
@@ -31,7 +31,7 @@ SeeedQTouch::SeeedQTouch() {
 
 
 // Check chip ID
-int SeeedQTouch::chipPresent() {
+int SeeedQTouch::chipPresent(void) {
     if (readReg(QTOUCH_REG_CHIPID) == 0x2e) {
         return 1;
     }


### PR DESCRIPTION
When compiling against "generic ESP8266" the routine is not found without the parameter